### PR TITLE
Missind dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "eslint": "^3.4.0",
     "eslint-config-standard": "^6.0.0",
+    "eslint-plugin-flowtype": "^2.11.4",
     "eslint-plugin-promise": "^2.0.1",
     "eslint-plugin-standard": "^2.0.0",
     "npm-run-all": "^3.0.0"


### PR DESCRIPTION
Added missing dev dependency.

Without it `npm start` fails with:

```
[...]
> eslint --ext .js,.vue src


Oops! Something went wrong! :(

ESLint couldn't find the plugin "eslint-plugin-flowtype". This can happen for a couple different reasons:

1. If ESLint is installed globally, then make sure eslint-plugin-flowtype is also installed globally. A globally-installed ESLint cannot find a locally-installed plugin.

2. If ESLint is installed locally, then it's likely that the plugin isn't installed correctly. Try reinstalling by running the following:

    npm i eslint-plugin-flowtype@latest --save-dev

If you still can't figure out the problem, please stop by https://gitter.im/eslint/eslint to chat with the team.
[...]
```
